### PR TITLE
PROD-2211  FCC Using TC Auth0 on FQDN -> PROD-2031_passthrough

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "serve:client-ci": "cd ./client && npm run serve-ci",
     "start": "npm-run-all create:* -p develop:server serve:client",
     "start-ci": "npm-run-all create:* -p start:server serve:client-ci",
+    "start-proxy": "local-ssl-proxy -n fcc.topcoder-dev.com -s 4431 -t 8000",
+    "start-proxy-api": "local-ssl-proxy -n fcc.topcoder-dev.com -s 44311 -t 3000",
     "start:server": "cd ./api-server && npm start",
     "storybook": "cd ./tools/ui-components && npm run storybook",
     "test": "run-s create:* build:curriculum build-workers test:*",

--- a/sample.topcoder.env
+++ b/sample.topcoder.env
@@ -1,0 +1,93 @@
+# ---------------------
+# BEGIN TOPCODER OVERRIDES
+# ---------------------
+
+# Auth0 - OAuth 2.0 Credentials
+AUTH0_CLIENT_ID=<GET ID FROM SITE ADMIN>
+AUTH0_CLIENT_SECRET=<GET SECRET FROM SITE ADMIN>
+AUTH0_DOMAIN=topcoder-dev.auth0.com
+
+# Application paths
+HOME_LOCATION=https://fcc.topcoder-dev.com:4431
+API_LOCATION=https://fcc.topcoder-dev.com:44311
+
+# Cookie Domain
+COOKIE_DOMAIN=".topcoder-dev.com"
+
+# ---------------------
+# END TOPCODER OVERRIDES
+# ---------------------
+
+# ---------------------
+# FCC API DEFAULTS
+# ---------------------
+
+# Database
+MONGOHQ_URL=mongodb://localhost:27017/freecodecamp
+
+# Logging
+SENTRY_DSN=dsn_from_sentry_dashboard
+SENTRY_CLIENT_DSN=dsn_from_sentry_dashboard
+SENTRY_ENVIRONMENT=staging
+
+# Session, Cookie and JWT encryption strings
+SESSION_SECRET=a_session_secret
+COOKIE_SECRET=a_cookie_secret
+JWT_SECRET=a_jwt_secret
+
+# ---------------------
+# Search
+# ---------------------
+
+# Client Search Bar
+ALGOLIA_APP_ID=app_id_from_algolia_dashboard
+ALGOLIA_API_KEY=api_key_from_algolia_dashboard
+
+# ---------------------
+# Donations
+# ---------------------
+
+# Stripe
+STRIPE_PUBLIC_KEY=pk_from_stripe_dashboard
+STRIPE_SECRET_KEY=sk_from_stripe_dashboard
+
+# PayPal
+PAYPAL_CLIENT_ID=id_from_paypal_dashboard
+PAYPAL_SECRET=secret_from_paypal_dashboard
+PAYPAL_VERIFY_WEBHOOK_URL=https://api.sandbox.paypal.com/v1/notifications/verify-webhook-signature
+PAYPAL_API_TOKEN_URL=https://api.sandbox.paypal.com/v1/oauth2/token
+PAYPAL_WEBHOOK_ID=webhook_id_from_paypal_dashboard
+
+# Patreon
+PATREON_CLIENT_ID=id_from_patreon_dashboard
+
+# ---------------------
+# Build variants
+# ---------------------
+DEPLOYMENT_ENV=staging
+FREECODECAMP_NODE_ENV=development
+
+# Languages to build
+CLIENT_LOCALE=english
+CURRICULUM_LOCALE=english
+
+# Show or hide WIP in progress challenges
+SHOW_UPCOMING_CHANGES=false
+SHOW_NEW_CURRICULUM=true
+
+# Application paths
+FORUM_LOCATION=https://forum.freecodecamp.org
+NEWS_LOCATION=https://www.freecodecamp.org/news
+RADIO_LOCATION=https://coderadio.freecodecamp.org
+
+# ---------------------
+# Debugging Mode Keys
+# ---------------------
+
+PEER=stuff
+DEBUG=true
+LOCAL_MOCK_AUTH=false
+CODESEE=false
+
+# Webhook proxy url from smee.io for PayPal
+WEBHOOK_PROXY_URL=


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2196

To verify this ticket:

1. copy the sample.topcoder.env file to .env
2. add the auth0 Account-App-New-Flow client ID and secret
- https://manage.auth0.com/dashboard/us/topcoder-dev/applications/BXWXUWnilVUPdN01t2Se29Tw2ZYNGZvH/settings
3. > npm run develop
4. > npm run start-proxy
5. > npm run start-proxy-api
6. go to the standalone FCC app at https://fcc.topcoder-dev.com:4431
7. click the Sign In button
- you might need to run FCC a private window to be permitted to access the api using the ssl proxy
8. log in using your topcoder-dev credentials
9. complete a step in a module

Verify in the Mongo DB that your progress appears as the user w/the email attached to your topcoder-dev creds