### PR TITLE
PROD-2289 create new user -> PROD-2031_passthrough-auth

### DIFF
--- a/api-server/src/common/models/User-Identity.js
+++ b/api-server/src/common/models/User-Identity.js
@@ -135,7 +135,11 @@ export default function initializeUserIdent(UserIdent) {
                 email: email,
                 emailVerified: true,
                 emailAuthLinkTTL: null,
-                emailVerifyTTL: null
+                emailVerifyTTL: null,
+                // TOPCODER: set the external id to the Auth0 string
+                // NOTE: this workflow only gets hit when running FCC
+                // as a standalone app
+                externalId: auth0IdString
               },
               err => {
                 if (err) {

--- a/api-server/src/common/models/user.js
+++ b/api-server/src/common/models/user.js
@@ -145,12 +145,7 @@ function populateRequiredFields(user) {
   }
 
   if (!user.externalId) {
-    // TOPCODER: the user.sub value is the Auth0 ID
-    // (e.g. auth0|12345) that we use to link the
-    // TC user to the local FCC user.
-    // TODO: get this working for new users PROD-2289
-    user.externalId = user.sub;
-    // user.externalId = uuid();
+    user.externalId = uuid();
   }
 
   if (!user.unsubscribeId) {

--- a/api-server/src/server/middlewares/request-authorization.js
+++ b/api-server/src/server/middlewares/request-authorization.js
@@ -10,10 +10,14 @@ import {
 } from '../utils/getSetAccessToken';
 import { getRedirectParams } from '../utils/redirection';
 // TOPCODER: we need to use the external ID (i.e. Auth0 ID)
-// to link w/the TC account
+// to link w/the TC account.
+// And if we don't find the user in the DB, we need to create
+// a new user and set its external ID
 import {
+  createUserByEmail as _createUserByEmail,
+  getUserByExternalId as _getUserByExternalId,
   /* getUserById as _getUserById */
-  getUserByExternalId as _getUserByExternalId
+  setExternalId as _setExternalId
 } from '../utils/user-stats';
 
 const authRE = /^\/auth\//;
@@ -57,9 +61,13 @@ export function isAllowedPath(path, pathsAllowedREs = _pathsAllowedREs) {
 export default function getRequestAuthorisation({
   jwtSecret = _jwtSecret,
   // TOPCODER: we need to use the external ID
-  // (i.e. Auth0 ID) to link w/the TC user
-  getUserByExternalId = _getUserByExternalId
+  // (i.e. Auth0 ID) to link w/the TC user.
+  // And if the user doesn't exist yet, we need
+  // to create it and set its external ID.
+  createUserByEmail = _createUserByEmail,
+  getUserByExternalId = _getUserByExternalId,
   // getUserById = _getUserById
+  setExternalId = _setExternalId
 } = {}) {
   return function requestAuthorisation(req, res, next) {
     const { origin } = getRedirectParams(req);
@@ -109,10 +117,31 @@ export default function getRequestAuthorisation({
               if (user) {
                 req.user = user;
               }
-              return;
+              return next();
             })
-            .then(next)
-            .catch(next)
+            .catch(err => {
+              // if the error is not the no user instance found error
+              // or if we don't have an access token with an email and
+              // external id, don't do any special error handling
+              if (
+                err !== 'No user instance found' ||
+                !accessToken?.email ||
+                !accessToken?.sub
+              ) {
+                return next();
+              }
+
+              // let's try to create the user
+              return createUserByEmail(accessToken.email)
+                .then(user => {
+                  if (!user) {
+                    return next();
+                  }
+                  req.user = user;
+                  return setExternalId(user, accessToken.sub).then(next);
+                })
+                .catch(next);
+            })
         );
       } else {
         return Promise.resolve(next());

--- a/api-server/src/server/utils/user-stats.js
+++ b/api-server/src/server/utils/user-stats.js
@@ -88,6 +88,32 @@ export function calcLongestStreak(cals, tz = 'UTC') {
 }
 
 // BEGIN TOPCODER:
+
+// we need to create a user and set its external ID if a valid token isn't found
+export function createUserByEmail(
+  email,
+  User = loopback.getModelByType('User')
+) {
+  return new Promise((resolve, reject) => {
+    return (
+      User.create$({ email })
+        .toPromise()
+        .then(user => resolve(user))
+        .catch(err => reject(err || 'error creating new user')),
+      (err, user) =>
+        err || !user ? reject(err || 'error creating new user') : resolve(user)
+    );
+  });
+}
+
+export function setExternalId(user, externalId) {
+  return new Promise((resolve, reject) =>
+    user.updateAttributes({ externalId }, err =>
+      err ? reject(err) : resolve()
+    )
+  );
+}
+
 // we need to use the external ID to get the user
 // instead of the internal ID
 export function getUserByExternalId(


### PR DESCRIPTION
This PR does 2 things:

- if a user has a valid token but no record in the DB, it will try to create a new user and set its external ID to the auth0 id
- when running as a standalone app, creating a new user will set its external ID to the auth0 ID.

To test this... 

1. Log into the Learn app as a user who doesn't have a record in the FCC db
2. Navigate to a specific lesson
3. You should see the FCC UI appear as if you're logged in and you should see a new record in the FCC db with the auth0 string as its external ID.
4. Log out
5. Log in again as the same user in step 1
6. Navigate to a specific lesson.
7. You should authenticate normally and no additional user should be created for you