### PR TITLE
PROD-2560 - fix issue where hints flash when you resubmit

### DIFF
--- a/client/src/templates/Challenges/classic/editor.tsx
+++ b/client/src/templates/Challenges/classic/editor.tsx
@@ -55,7 +55,8 @@ import {
   stopResetting,
   isProjectPreviewModalOpenSelector,
   openModal,
-  isChallengeCompletedSelector
+  isChallengeCompletedSelector,
+  testsRunningSelector
 } from '../redux';
 import GreenPass from '../../../assets/icons/green-pass';
 import Code from '../../../assets/icons/code';
@@ -107,6 +108,7 @@ interface EditorProps {
   }) => void;
   usesMultifileEditor: boolean;
   isChallengeCompleted: boolean;
+  testsRunning: boolean;
 }
 
 // TODO: this is grab bag of unrelated properties.  There's no need for them to
@@ -136,6 +138,7 @@ const mapStateToProps = createSelector(
   userSelector,
   challengeTestsSelector,
   isChallengeCompletedSelector,
+  testsRunningSelector,
   (
     canFocus: boolean,
     { challengeType }: { challengeType: number },
@@ -146,7 +149,8 @@ const mapStateToProps = createSelector(
     isSignedIn: boolean,
     { theme = Themes.Default }: { theme: Themes },
     tests: [{ text: string; testString: string }],
-    isChallengeCompleted: boolean
+    isChallengeCompleted: boolean,
+    testsRunning: boolean
   ) => ({
     canFocus: open ? false : canFocus,
     challengeType,
@@ -156,7 +160,8 @@ const mapStateToProps = createSelector(
     output,
     theme,
     tests,
-    isChallengeCompleted
+    isChallengeCompleted,
+    testsRunning
   })
 );
 
@@ -584,6 +589,7 @@ const Editor = (props: EditorProps): JSX.Element => {
         challengeHasErrors={challengeHasErrors()}
         tryToSubmitChallenge={tryToSubmitChallenge}
         isEditorInFocus={isEditorInFocus}
+        isRunningTests={props.testsRunning}
       />,
       outputNode,
       callback
@@ -1089,7 +1095,7 @@ const Editor = (props: EditorProps): JSX.Element => {
     dataRef.current.outputNode = lowerJawElement;
     updateOutputZone();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.tests]);
+  }, [props.tests, props.testsRunning]);
 
   useEffect(() => {
     const editor = dataRef.current.editor;

--- a/client/src/templates/Challenges/classic/show.tsx
+++ b/client/src/templates/Challenges/classic/show.tsx
@@ -46,7 +46,8 @@ import {
   previewMounted,
   updateChallengeMeta,
   openModal,
-  setEditorFocusability
+  setEditorFocusability,
+  testsRunningSelector
 } from '../redux';
 import { savedChallengesSelector } from '../../../redux';
 import { getGuideUrl } from '../utils';
@@ -61,6 +62,7 @@ import '../components/test-frame.css';
 const mapStateToProps = createStructuredSelector({
   challengeFiles: challengeFilesSelector,
   tests: challengeTestsSelector,
+  testsRunning: testsRunningSelector,
   output: consoleOutputSelector,
   isChallengeCompleted: isChallengeCompletedSelector,
   savedChallenges: savedChallengesSelector
@@ -104,6 +106,7 @@ interface ShowClassicProps {
   };
   t: TFunction;
   tests: Test[];
+  testsRunning: boolean;
   updateChallengeMeta: (arg0: ChallengeMeta) => void;
   openModal: (modal: string) => void;
   setEditorFocusability: (canFocus: boolean) => void;
@@ -337,6 +340,7 @@ class ShowClassic extends Component<ShowClassicProps, ShowClassicState> {
         instructionsPanelRef={this.instructionsPanelRef}
         showToolPanel={showToolPanel}
         videoUrl={this.getVideoUrl()}
+        testsRunning={this.props.testsRunning}
       />
     );
   }

--- a/client/src/templates/Challenges/components/side-panel.tsx
+++ b/client/src/templates/Challenges/components/side-panel.tsx
@@ -27,6 +27,7 @@ interface SidePanelProps {
   instructionsPanelRef: React.RefObject<HTMLDivElement>;
   showToolPanel: boolean;
   tests: Test[];
+  testsRunning: boolean;
   videoUrl: string;
 }
 
@@ -38,6 +39,7 @@ export function SidePanel({
   instructionsPanelRef,
   showToolPanel = false,
   tests,
+  testsRunning,
   videoUrl
 }: SidePanelProps): JSX.Element {
   const isChallengeComplete = tests.every(test => test.pass && !test.err);
@@ -85,6 +87,7 @@ export function SidePanel({
             guideUrl={guideUrl}
             videoUrl={videoUrl}
             challengeIsCompleted={isChallengeComplete}
+            isRunningTests={testsRunning}
           />
         )}
         <TestSuite tests={tests} />
@@ -93,6 +96,7 @@ export function SidePanel({
             guideUrl={guideUrl}
             videoUrl={videoUrl}
             challengeIsCompleted={isChallengeComplete}
+            isRunningTests={testsRunning}
           />
         )}
       </div>

--- a/client/src/templates/Challenges/components/tool-panel.tsx
+++ b/client/src/templates/Challenges/components/tool-panel.tsx
@@ -52,6 +52,7 @@ interface ToolPanelProps {
   saveChallenge: () => void;
   isMobile?: boolean;
   isSignedIn: boolean;
+  isRunningTests?: boolean;
   openHelpModal: () => void;
   openVideoModal: () => void;
   openResetModal: () => void;
@@ -66,6 +67,7 @@ function ToolPanel({
   saveChallenge,
   isMobile,
   isSignedIn,
+  isRunningTests,
   openHelpModal,
   openVideoModal,
   openResetModal,
@@ -95,6 +97,7 @@ function ToolPanel({
           onClick={handleRunTests}
         >
           {isMobile ? t('buttons.run') : t('buttons.run-test')}
+          {isRunningTests && ' ...'}
         </Button>
       )}
       {challengeIsCompleted && (

--- a/client/src/templates/Challenges/redux/action-types.js
+++ b/client/src/templates/Challenges/redux/action-types.js
@@ -18,6 +18,7 @@ export const actionTypes = createTypes(
     'updateTests',
     'updateLogs',
     'cancelTests',
+    'updateTestsRunning',
 
     'logsToConsole',
 

--- a/client/src/templates/Challenges/redux/execute-challenge-saga.js
+++ b/client/src/templates/Challenges/redux/execute-challenge-saga.js
@@ -47,7 +47,8 @@ import {
   updateTests,
   openModal,
   isBuildEnabledSelector,
-  disableBuildOnError
+  disableBuildOnError,
+  updateTestsRunning
 } from './';
 
 // How long before bailing out of a preview.
@@ -101,6 +102,7 @@ export function* executeChallengeSaga({ payload }) {
   try {
     yield put(initLogs());
     yield put(initConsole(i18next.t('learn.running-tests')));
+    yield put(updateTestsRunning(true));
     // reset tests to initial state
     const tests = (yield select(challengeTestsSelector)).map(
       ({ text, testString }) => ({ text, testString })
@@ -139,6 +141,7 @@ export function* executeChallengeSaga({ payload }) {
     }
     yield put(updateConsole(i18next.t('learn.tests-completed')));
     yield put(logsToConsole(i18next.t('learn.console-output')));
+    yield put(updateTestsRunning(false));
   } catch (e) {
     yield put(updateConsole(e));
   } finally {

--- a/client/src/templates/Challenges/redux/index.js
+++ b/client/src/templates/Challenges/redux/index.js
@@ -36,6 +36,7 @@ const initialState = {
   isBuildEnabled: true,
   isResetting: false,
   logsOut: [],
+  testsRunning: false,
   modal: {
     completion: false,
     help: false,
@@ -80,6 +81,7 @@ export const createQuestion = createAction(actionTypes.createQuestion);
 export const initTests = createAction(actionTypes.initTests);
 export const updateTests = createAction(actionTypes.updateTests);
 export const cancelTests = createAction(actionTypes.cancelTests);
+export const updateTestsRunning = createAction(actionTypes.updateTestsRunning);
 
 export const initConsole = createAction(actionTypes.initConsole);
 export const initLogs = createAction(actionTypes.initLogs);
@@ -134,6 +136,7 @@ export const challengeFilesSelector = state => state[ns].challengeFiles;
 export const challengeMetaSelector = state => state[ns].challengeMeta;
 export const challengeTestsSelector = state => state[ns].challengeTests;
 export const consoleOutputSelector = state => state[ns].consoleOut;
+export const testsRunningSelector = state => state[ns].testsRunning;
 export const completedChallengesIds = state =>
   completedChallengesSelector(state).map(node => node.id);
 export const isChallengeCompletedSelector = state => {
@@ -260,6 +263,10 @@ export const reducer = handleActions(
     [actionTypes.updateConsole]: (state, { payload }) => ({
       ...state,
       consoleOut: state.consoleOut.concat(payload)
+    }),
+    [actionTypes.updateTestsRunning]: (state, { payload }) => ({
+      ...state,
+      testsRunning: payload
     }),
     [actionTypes.initLogs]: state => ({
       ...state,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2560 - Issue in checking and submitting the code

This PR:
- fix issue where tests errors and hints are flashing when you re-check code
- once a lesson is completed, keep the "completed" state even if the user changes code. This is according to latest FCC changes/behavior: https://github.com/freeCodeCamp/freeCodeCamp/blob/main/client/src/templates/Challenges/classic/lower-jaw.tsx#L104
- add a new state prop to keep track of running tests. This helps keeping the UI in sync and will help us add a loader to the "check code" buttons while the tests are running (right now I only added '...' as an indicator)