### PR TITLE
TCA-354 - fix handler for external urls when url is fcc lesson

### DIFF
--- a/client/src/components/layouts/tc-integration.tsx
+++ b/client/src/components/layouts/tc-integration.tsx
@@ -144,7 +144,7 @@ class TcIntegrationLayout extends Component<TcIntegrationLayoutProps> {
       // provider.
 
       // set the pathname for the 2 flavors of lesson URL
-      const platformPathPrefix = 'learn/freecodecamp';
+      const platformPathPrefix = 'learn/freeCodeCamp';
       const learnPrefix = '/learn/';
       let updateHost = false;
       if (url.host === `learn.${fccHost}`) {


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-354?focusedCommentId=28556

- update handler for links to FCC lessons. Update provider name from "freecodecamp" to "freeCodeCamp" (case sensitive).