### PR TITLE
TCA-480 - replace fcc links located in the lesson content

### DIFF
--- a/curriculum/challenges/chinese-traditional/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/chinese-traditional/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ myFun();
 修改函數 `abTest` 當 `a` 或 `b` 小於 `0` 時，函數立即返回一個 `undefined` 並退出。
 
 **提示**  
-記住 <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> 是關鍵字 </a>，不是字符串.
+記住 <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> 是關鍵字 </a>，不是字符串.
 
 # --hints--
 

--- a/curriculum/challenges/chinese-traditional/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/chinese-traditional/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ dashedName: use-assert-isok-and-assert-isnotok
 
 `isOk()` 用來測試值是否爲真值，`isNotOk()` 用來測試值是否爲假值。
 
-可以在[過濾數組中的假值](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer)這個挑戰中瞭解更多關於真值和假值的信息。
+可以在[過濾數組中的假值](https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer)這個挑戰中瞭解更多關於真值和假值的信息。
 
 # --instructions--
 

--- a/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/chinese/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ myFun();
 修改函数 `abTest` 当 `a` 或 `b` 小于 `0` 时，函数立即返回一个 `undefined` 并退出。
 
 **提示**  
-记住 <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> 是关键字 </a>，不是字符串.
+记住 <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> 是关键字 </a>，不是字符串.
 
 # --hints--
 

--- a/curriculum/challenges/chinese/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/chinese/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ dashedName: use-assert-isok-and-assert-isnotok
 
 `isOk()` 用来测试值是否为真值，`isNotOk()` 用来测试值是否为假值。
 
-可以在[过滤数组中的假值](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer)这个挑战中了解更多关于真值和假值的信息。
+可以在[过滤数组中的假值](https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer)这个挑战中了解更多关于真值和假值的信息。
 
 # --instructions--
 

--- a/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/english/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ The above will display the string `Hello` in the console, and return the string 
 Modify the function `abTest` so that if `a` or `b` are less than `0` the function will immediately exit with a value of `undefined`.
 
 **Hint**  
-Remember that <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> is a keyword</a>, not a string.
+Remember that <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> is a keyword</a>, not a string.
 
 # --hints--
 

--- a/curriculum/challenges/english/03-front-end-development-libraries/redux/create-a-redux-store.md
+++ b/curriculum/challenges/english/03-front-end-development-libraries/redux/create-a-redux-store.md
@@ -20,7 +20,7 @@ The Redux `store` is an object which holds and manages application `state`. Ther
 
 Declare a `store` variable and assign it to the `createStore()` method, passing in the `reducer` as an argument.
 
-**Note:** The code in the editor uses ES6 default argument syntax to initialize this state to hold a value of `5`. If you're not familiar with default arguments, you can refer to the <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6 section in the Curriculum</a> which covers this topic.
+**Note:** The code in the editor uses ES6 default argument syntax to initialize this state to hold a value of `5`. If you're not familiar with default arguments, you can refer to the <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6 section in the Curriculum</a> which covers this topic.
 
 # --hints--
 

--- a/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/english/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ As a reminder, this project is being built upon the following starter project on
 
 `isOk()` will test for a truthy value, and `isNotOk()` will test for a falsy value.
 
-To learn more about truthy and falsy values, try our <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">Falsy Bouncer</a> challenge.
+To learn more about truthy and falsy values, try our <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">Falsy Bouncer</a> challenge.
 
 # --instructions--
 

--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/fibonacci-word.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/fibonacci-word.md
@@ -16,7 +16,7 @@ Form   F_Word<sub>3</sub>  as  F_Word<sub>2</sub>   concatenated with  F_Word<su
 Form   F_Word<sub>n</sub>  as  F_Word<sub>n-1</sub>  concatenated with  F_word<sub>n-2</sub>
 </pre>
 
-Entropy calculation is required in this challenge, <a href="https://www.freecodecamp.org/learn/coding-interview-prep/rosetta-code/entropy" target="_blank" rel="noopener noreferrer nofollow">as shown in this Rosetta Code challenge</a>
+Entropy calculation is required in this challenge, <a href="https://platform-ui.topcoder.com/learn/coding-interview-prep/rosetta-code/entropy" target="_blank" rel="noopener noreferrer nofollow">as shown in this Rosetta Code challenge</a>
 
 # --instructions--
 

--- a/curriculum/challenges/espanol/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/espanol/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ Lo anterior mostrará la cadena `Hello` en la consola y devolverá la cadena `Wo
 Modifica la función `abTest` para que cuando `a` o `b` sean menores que `0` la función salga inmediatamente con un valor `undefined`.
 
 **Pista**  
-Recuerda que <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> es una palabra clave</a>, no una cadena.
+Recuerda que <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> es una palabra clave</a>, no una cadena.
 
 # --hints--
 

--- a/curriculum/challenges/espanol/03-front-end-development-libraries/redux/create-a-redux-store.md
+++ b/curriculum/challenges/espanol/03-front-end-development-libraries/redux/create-a-redux-store.md
@@ -20,7 +20,7 @@ El `store` (almacén) de Redux es un objeto que guarda y gestiona el `state` (es
 
 Declara una variable `store` y asígnala al método `createStore()`, pasando el `reducer` como argumento.
 
-**Nota:** El código del editor utiliza la sintaxis de los argumentos por defecto de ES6 para inicializar este estado y mantener un valor de `5`. Si no está familiarizado con los argumentos predeterminados, puede consultar el<a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6 section in the Curriculum</a> que cubre este tema.
+**Nota:** El código del editor utiliza la sintaxis de los argumentos por defecto de ES6 para inicializar este estado y mantener un valor de `5`. Si no está familiarizado con los argumentos predeterminados, puede consultar el<a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6 section in the Curriculum</a> que cubre este tema.
 
 # --hints--
 

--- a/curriculum/challenges/espanol/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/espanol/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ Como recordatorio, este proyecto está siendo construido con base en el siguient
 
 `isOk()` prueba un valor verdadero y `isNotOk()` prueba un valor falso.
 
-Para aprender más sobre los valores verdaderos y falsos, prueba nuestro desafío de <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">Falsy Bouncer</a>.
+Para aprender más sobre los valores verdaderos y falsos, prueba nuestro desafío de <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">Falsy Bouncer</a>.
 
 # --instructions--
 

--- a/curriculum/challenges/german/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/german/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ Das obige Beispiel zeigt den String `Hello` in der Konsole an und gibt den Strin
 Ändere die Funktion `abTest` so, dass die Funktion sofort mit einem Wert von `undefined` beendet wird, wenn `a` oder `b` kleiner als `0` sind.
 
 **Hinweis:**  
-Denk daran, dass <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> ein Schlüsselwort</a> und kein String ist.
+Denk daran, dass <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> ein Schlüsselwort</a> und kein String ist.
 
 # --hints--
 

--- a/curriculum/challenges/german/03-front-end-development-libraries/redux/create-a-redux-store.md
+++ b/curriculum/challenges/german/03-front-end-development-libraries/redux/create-a-redux-store.md
@@ -20,7 +20,7 @@ Der Redux `store` ist ein Objekt, das den Zustand (`state`) der Anwendung hält 
 
 Deklariere eine `store`-Variable und weise sie der `createStore()`-Methode zu, indem du den `reducer` als Argument übergibst.
 
-**Hinweis:** Der Code im Editor verwendet die ES6-Standardargumentsyntax, um diesen Zustand mit einem Wert von `5` zu initialisieren. Wenn du mit Standardargumenten nicht vertraut bist, kannst auf <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6-Abschnitt in den Lehrinhalten </a> zurückgreifen, in dem dieses Thema behandelt wird.
+**Hinweis:** Der Code im Editor verwendet die ES6-Standardargumentsyntax, um diesen Zustand mit einem Wert von `5` zu initialisieren. Wenn du mit Standardargumenten nicht vertraut bist, kannst auf <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">ES6-Abschnitt in den Lehrinhalten </a> zurückgreifen, in dem dieses Thema behandelt wird.
 
 # --hints--
 

--- a/curriculum/challenges/italian/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/italian/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ Quanto sopra mostrerà la stringa `Hello` nella console, e restituirà la string
 Modifica la funzione `abTest` in modo che se `a` o `b` sono inferiori a `0` la funzione esce immediatamente con un valore di `undefined`.
 
 **Suggerimento**  
-Ricorda che <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> è una parola chiave</a>, non una stringa.
+Ricorda che <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> è una parola chiave</a>, non una stringa.
 
 # --hints--
 

--- a/curriculum/challenges/italian/03-front-end-development-libraries/redux/create-a-redux-store.md
+++ b/curriculum/challenges/italian/03-front-end-development-libraries/redux/create-a-redux-store.md
@@ -20,7 +20,7 @@ Lo `store` di Redux è un oggetto che detiene e gestisce lo `state` dell'applica
 
 Dichiara una variabile `store` e assegnala al metodo `createStore()`, passando il `reducer` come argomento.
 
-**Nota:** Il codice nell'editor utilizza la sintassi predefinita degli argomenti ES6 per inizializzare questo stato in modo da contenere un valore di `5`. Se non hai familiarità con gli argomenti predefiniti, puoi fare riferimento alla <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">sezione ES6 nel Curriculum</a> che tratta questo argomento.
+**Nota:** Il codice nell'editor utilizza la sintassi predefinita degli argomenti ES6 per inizializzare questo stato in modo da contenere un valore di `5`. Se non hai familiarità con gli argomenti predefiniti, puoi fare riferimento alla <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow">sezione ES6 nel Curriculum</a> che tratta questo argomento.
 
 # --hints--
 

--- a/curriculum/challenges/italian/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/italian/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ Come promemoria, questo progetto verrà costruito a partire dalla seguente bozza
 
 `isOk()` verificherà se un valore è veritiero e `isNotOk()` verificherà se un valore è falso.
 
-Per saperne di più sui valori veritieri e falsi, prova la nostra sfida <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">Falsy Bouncer</a>.
+Per saperne di più sui valori veritieri e falsi, prova la nostra sfida <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">Falsy Bouncer</a>.
 
 # --instructions--
 

--- a/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/portuguese/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ O código acima exibirá no console a string `Hello`, e retorna a string `World`
 Modifique a função `abTest` para que se `a` ou `b` forem menores que `0` a função irá imediatamente terminar retornando o valor de `undefined`.
 
 **Dica**  
-Lembre-se de que <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> é uma palavra-chave</a> e não uma string.
+Lembre-se de que <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables" target="_blank" rel="noopener noreferrer nofollow"><code>undefined</code> é uma palavra-chave</a> e não uma string.
 
 # --hints--
 

--- a/curriculum/challenges/portuguese/03-front-end-development-libraries/redux/create-a-redux-store.md
+++ b/curriculum/challenges/portuguese/03-front-end-development-libraries/redux/create-a-redux-store.md
@@ -20,7 +20,7 @@ O `store` do Redux é um objeto que contém e gerencia o `state` da aplicação.
 
 Declare uma variável `store` e atribua-a ao método `createStore()`, passando no `reducer` como argumento.
 
-**Observação:** o código no editor usa a sintaxe de argumento padrão ES6 para inicializar este estado para ter um valor de `5`. Se você não está familiarizado com os argumentos padrão, você pode se referir <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow"> à seção sobre ES6 do currículo</a> que aborda este tópico.
+**Observação:** o código no editor usa a sintaxe de argumento padrão ES6 para inicializar este estado para ter um valor de `5`. Se você não está familiarizado com os argumentos padrão, você pode se referir <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/es6/set-default-parameters-for-your-functions" target="_blank" rel="noopener noreferrer nofollow"> à seção sobre ES6 do currículo</a> que aborda este tópico.
 
 # --hints--
 

--- a/curriculum/challenges/portuguese/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/portuguese/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ Lembrando que este projeto está sendo construído a partir do <a href="https://
 
 `isOk()` testará se um valor é verdadeiro e `isNotOk()` testará se um valor é falso.
 
-Para saber mais sobre valores verdadeiros e falsos, experimente nosso <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">desafio</a> Remover falsos.
+Para saber mais sobre valores verdadeiros e falsos, experimente nosso <a href="https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer" target="_blank" rel="noopener noreferrer nofollow">desafio</a> Remover falsos.
 
 # --instructions--
 

--- a/curriculum/challenges/portuguese/10-coding-interview-prep/rosetta-code/fibonacci-word.md
+++ b/curriculum/challenges/portuguese/10-coding-interview-prep/rosetta-code/fibonacci-word.md
@@ -16,7 +16,7 @@ Forme a F_Word<sub>3</sub>  como  F_Word<sub>2</sub>   concatenada com a  F_Word
 Forme a F_Word<sub>n</sub>  como  F_Word<sub>n-1</sub>  concatenada com a  F_word <sub>n-2</sub>
 </pre>
 
-É necessário o cálculo de entropia neste desafio, <a href="https://www.freecodecamp.org/learn/coding-interview-prep/rosetta-code/entropy" target="_blank" rel="noopener noreferrer nofollow">como mostrado neste desafio do Rosetta Code</a>
+É necessário o cálculo de entropia neste desafio, <a href="https://platform-ui.topcoder.com/learn/coding-interview-prep/rosetta-code/entropy" target="_blank" rel="noopener noreferrer nofollow">como mostrado neste desafio do Rosetta Code</a>
 
 # --instructions--
 

--- a/curriculum/challenges/ukrainian/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
+++ b/curriculum/challenges/ukrainian/02-javascript-algorithms-and-data-structures/basic-javascript/return-early-pattern-for-functions.md
@@ -29,7 +29,7 @@ myFun();
 Модифікуйте функцію `abTest` і тому, якщо `a` або `b` дорівнюватиме менше `0`, функція відразу вийде зі значенням `undefined`.
 
 **Підказка**  
-Пам'ятайте, що [`undefined` - це ключове слово](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables), а не рядок.
+Пам'ятайте, що [`undefined` - це ключове слово](https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-javascript/understanding-uninitialized-variables), а не рядок.
 
 # --hints--
 

--- a/curriculum/challenges/ukrainian/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
+++ b/curriculum/challenges/ukrainian/06-quality-assurance/quality-assurance-and-testing-with-chai/use-assert.isok-and-assert.isnotok.md
@@ -12,7 +12,7 @@ dashedName: use-assert-isok-and-assert-isnotok
 
 `isOk()` перевіряє правдиве значення, а `isNotOk()` перевіряє хибне значення.
 
-Щоб дізнатися більше про правдиві й хибні значення, перейдіть на завдання [Хибний вибивало](https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer).
+Щоб дізнатися більше про правдиві й хибні значення, перейдіть на завдання [Хибний вибивало](https://platform-ui.topcoder.com/learn/javascript-algorithms-and-data-structures/basic-algorithm-scripting/falsy-bouncer).
 
 # --instructions--
 


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-480

Replace the FCC courses links that are located in the lesson content with links pointed to platform-ui.

Example lesson that has a link to another course:

https://platform-ui.topcoder-dev.com/learn/freeCodeCamp/quality-assurance/quality-assurance-and-testing-with-chai/use-assert-isok-and-assert-isnotok

![image](https://user-images.githubusercontent.com/2527433/192721620-988a6766-71c6-431f-b9a6-cf6a29828d9b.png)
