### PR TITLE
TCA-467 - fix label for submit button

### DIFF
--- a/client/i18n/locales/english/translations.json
+++ b/client/i18n/locales/english/translations.json
@@ -50,6 +50,7 @@
     "reset-lesson": "Reset this lesson",
     "run": "Run",
     "run-test": "Run the Tests (Ctrl + Enter)",
+    "run-test-2": "Run the Tests",
     "check-code": "Check Your Code (Ctrl + Enter)",
     "check-code-2": "Check Your Code",
     "reset": "Reset",

--- a/client/src/templates/Challenges/projects/backend/Show.tsx
+++ b/client/src/templates/Challenges/projects/backend/Show.tsx
@@ -219,7 +219,7 @@ class BackEnd extends Component<BackEndProps> {
 
     const isChallengeComplete = tests.every(test => test.pass && !test.err);
     const submitBtnLabel: string = !isChallengeComplete
-      ? `${t('buttons.run-test')}${testsRunning ? ' ...' : ''}`
+      ? `${t('buttons.run-test-2')}${testsRunning ? ' ...' : ''}`
       : t('buttons.submit-and-go');
 
     const blockNameTitle = `${t(


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TCA-467

Updates the label for the submit button for the project type challenges (eg. backend course).
Remove the "ctrl + enter" hint, as it is not listening to that. Instead it is just a simple form and by hitting enter (like in a normal form) will try to submit it. No additional hint was added as this is common sense (submitting forms by hitting enter).